### PR TITLE
Dev 018 added new parameter ConnectionSemaphore 

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,8 +1,9 @@
 proxy:
   defaultPort: 8080
-  deadLineTimeMs: 1
+  deadLineTimeSeconds: 2
   shutdownTimeoutSeconds: 10
   sizeCopyBufferIo: 32768
+  connectionSemaphore: 200
 
 peers:
   - name: test_backend_1

--- a/internal/proxy/config.go
+++ b/internal/proxy/config.go
@@ -2,7 +2,8 @@ package proxy
 
 type Config struct {
 	DefaultPort            string `yaml:"defaultPort"`
-	DeadLineTimeMS         uint   `yaml:"deadLineTimeMs"`
+	DeadLineTimeSeconds    uint   `yaml:"deadLineTimeSeconds"`
 	ShutdownTimeoutSeconds uint   `yaml:"shutdownTimeoutSeconds"`
 	SizeCopyBufferIO       uint   `yaml:"sizeCopyBufferIo"`
+	ConnectionSemaphore    uint   `yaml:"connectionSemaphore"`
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -42,7 +42,7 @@ func TestCheckNewConnection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go testProxy.CheckNewConnection(ctx, proxySrv)
+	go testProxy.AcceptConnections(ctx, proxySrv)
 
 	conn, err := net.Dial("tcp", proxySrv.Addr().String())
 	if err != nil {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -34,7 +34,7 @@ func TestCheckNewConnection(t *testing.T) {
 
 	//nolint:exhaustivestruct,exhaustruct
 	testProxy := &proxy.Proxy{
-		Cfg:    &proxy.Config{DeadLineTimeMS: 100},
+		Cfg:    &proxy.Config{DeadLineTimeSeconds: 100},
 		Logger: logger,
 		Peers:  peers.New(listPeer),
 	}


### PR DESCRIPTION
The "ConnectionSemaphore" parameter has been added to the code, and it is of type "uint". This parameter is used to control the maximum number of concurrent connections that can be established through the proxy server at any given time. The value of "connectionSemaphore" is specified in the YAML configuration file. The purpose of this parameter is to limit the number of connections to prevent overloading the server and ensure its stability and performance. To use this parameter, simply specify the desired number of concurrent connections in the "connectionSemaphore" field in the YAML configuration file. The parameter can be accessed and utilized in the code by referring to it as "p.Cfg.ConnectionSemaphore".